### PR TITLE
Improved comments.

### DIFF
--- a/Lab06_Exercise01/Lab06_Exercise01.vcxproj
+++ b/Lab06_Exercise01/Lab06_Exercise01.vcxproj
@@ -60,6 +60,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </PostBuildEvent>
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
+      <PtxAsOptionV>true</PtxAsOptionV>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -83,6 +84,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     </PostBuildEvent>
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
+      <PtxAsOptionV>true</PtxAsOptionV>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Lab06_Exercise01/exercise01_sln.cu
+++ b/Lab06_Exercise01/exercise01_sln.cu
@@ -145,11 +145,13 @@ int main(int argc, char **argv)
 	checkCUDAError("CUDA kernel execution and timing");
 
 	cudaEventElapsedTime(&msec, start, stop);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	checkCUDAError("CUDA timing");
 
-	// Compute the ocupancy
-	occupancy = 0;
+	// Ex 1.2.1: Compute the occupancy
+	cudaDeviceProp deviceProp;
+	cudaGetDeviceProperties(&deviceProp, 0);
+	occupancy = (deviceProp.maxBlocksPerMultiProcessor * threads.x * threads.y * threads.z) / (float)(deviceProp.maxThreadsPerMultiProcessor * deviceProp.multiProcessorCount);
 
 	// Copy result from device to host
 	cudaMemcpyFromSymbol(h_C, d_C, mem_size_C);


### PR DESCRIPTION
I haven't modified comments to Ex1 Part 1, it was already pretty thorough and it's hard to tie individual statements to specific exercises, as there's alot of overlap.

Ex1, Part 2 was missing, occupancy was not being calculated, have added that. Also Verbose PTX output (the last task) wasn't enabled, that's included in 2nd commit.

Ex2 has unusual passing of block size to kernel via `__constant__`, gave an excuse for it in the comment.